### PR TITLE
fix for Macintosh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,27 @@
-language: cpp
+dist: trusty
+
+language:
+  - c++
 
 compiler:
-  - g++
+  - gcc-5.3
+  # - clang
 
-sudo: required
+matrix:
+  include:
+    - os: linux
+    - os: osx
+      osx_image: xcode8
 
-before_script:
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8"; fi
-  addons:
-    apt:
-      sources:
-      - ubuntu-toolchain-r-test
-      packages:
-      - g++-4.8
+before_install:
+  - pwd
+  - echo $PATH
+  # - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update             ; fi
+  # - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew upgrade       ; fi
 
 script:
-  - cd src
-  - make lsm_tree_single_thread
+  - g++ -std=c++11 -O3 test_data.cpp -o test_data 
+  - cd src && make -j8 blinktree_single_thread blinktree_with_queue blinktree_multi_thread lsmtree_single_thread lsmtree_with_queue lsmtree_multi_thread
 
 notifications:
   email:

--- a/src/mushroom/pthread_spin_lock_shim.h
+++ b/src/mushroom/pthread_spin_lock_shim.h
@@ -1,0 +1,62 @@
+#ifndef PTHREAD_SPIN_LOCK_SHIM
+#define PTHREAD_SPIN_LOCK_SHIM
+
+// I am not sure is there any more options
+#ifdef __APPLE__
+
+#include <cerrno>
+
+#include <atomic>
+#include <thread>  // NOLINT(build/c++11) for std::this_thread::yield();
+
+// workaround for pshared
+// ref: https://linux.die.net/man/3/pthread_spin_init
+#ifndef PTHREAD_PROCESS_SHARED
+#define PTHREAD_PROCESS_SHARED 1
+#endif
+#ifndef PTHREAD_PROCESS_PRIVATE
+#define PTHREAD_PROCESS_PRIVATE 2
+#endif
+
+#ifndef UNUSED
+#define UNUSED(expr) (void)(expr)
+#endif  // UNUSED
+
+typedef std::atomic_flag pthread_spinlock_t;
+
+static inline int pthread_spin_destroy(pthread_spinlock_t *lock) {
+  UNUSED(lock);
+  // do nothing
+  return 0;
+}
+
+static inline int pthread_spin_lock(pthread_spinlock_t *lock) {
+  while (lock->test_and_set(std::memory_order_acquire)) {
+    // wait
+    std::this_thread::yield();
+  }
+  return 0;
+}
+
+static inline int pthread_spin_trylock(pthread_spinlock_t *lock) {
+  if (lock->test_and_set(std::memory_order_acquire)) {
+    return 0;
+  } else {
+    return EBUSY;
+  }
+}
+
+static inline int pthread_spin_unlock(pthread_spinlock_t *lock) {
+  lock->clear(std::memory_order_release);
+  return 0;
+}
+
+static inline int pthread_spin_init(pthread_spinlock_t *lock, int pshared) {
+  UNUSED(pshared);
+  pthread_spin_unlock(lock);
+  return 0;
+}
+
+#endif  // __APPLE__
+
+#endif

--- a/src/mushroom/slice.hpp
+++ b/src/mushroom/slice.hpp
@@ -28,7 +28,7 @@ class Key
 		}
 		Key& operator=(const Key &key) {
 			if (size_ != key.size_) {
-				delete data_;
+				delete [] data_;
 				size_ = key.size_;
 				data_ = new char[size_];
 			}
@@ -45,7 +45,7 @@ class Key
 
 		std::string ToString() const { return std::string(data_, size_) + "\n"; }
 
-		~Key() { delete data_; }
+		~Key() { delete [] data_; }
 
 		uint32_t size_;
 		char    *data_;

--- a/src/mushroom/utility.hpp
+++ b/src/mushroom/utility.hpp
@@ -10,6 +10,8 @@
 
 #include <cstdint>
 
+#include "pthread_spin_lock_shim.h"
+
 namespace Mushroom {
 
 typedef uint32_t valptr;

--- a/test/thread.cpp
+++ b/test/thread.cpp
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
 	auto beg = std::chrono::high_resolution_clock::now();
 	int all = total == 1 ? 1 : total / thread_num;
 	pthread_t ids[thread_num];
-	ThreadArg args[thread_num];
+	ThreadArg *args = new ThreadArg[thread_num];
 	for (int i = 0; i != thread_num; ++i) {
 		args[i].i = i;
 		args[i].all = all;
@@ -113,6 +113,7 @@ int main(int argc, char **argv)
 	// auto t2 = std::chrono::duration<double, std::ratio<1>>(end - beg).count();
 	// printf("\033[34mget time: %f  s\033[0m\n", t2);
 
+	delete [] args;
 	db->Close();
 	delete db;
 

--- a/test_data.cpp
+++ b/test_data.cpp
@@ -36,7 +36,7 @@ class MushroomDBTestData
 			std::ostringstream os;
 			os << total;
 			if (access("data", F_OK))
-				assert(mkdir("data", S_IRUSR | S_IWUSR | S_IROTH) >= 0);
+				assert(mkdir("data", S_IRUSR | S_IWUSR | S_IXUSR | S_IROTH) >= 0);
 			std::string base("data/"+os.str());
 			for (int i = 0; i != file_num; ++i) {
 				std::ostringstream o;


### PR DESCRIPTION
1. pthread_spin_lock does not exist in my apple clang based tool chain
```
$ g++ -v
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 8.1.0 (clang-802.0.42)
Target: x86_64-apple-darwin16.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```
2. add S_IXUSR for directory "data". This will help user to visit the content
3. delete [] is supposed to paired with new []